### PR TITLE
add Skynet Api Key support

### DIFF
--- a/siaskynet/__init__.py
+++ b/siaskynet/__init__.py
@@ -56,6 +56,11 @@ class SkynetClient():
             headers["User-Agent"] = opts["custom_user_agent"]
             kwargs["headers"] = headers
 
+        if opts["skynet_api_key"] is not None:
+            headers = kwargs.get("headers", {})
+            headers["Skynet-Api-Key"] = opts["skynet_api_key"]
+            kwargs["headers"] = headers
+
         if opts["timeout_seconds"] is not None:
             kwargs["timeout"] = opts["timeout_seconds"]
 

--- a/siaskynet/utils.py
+++ b/siaskynet/utils.py
@@ -12,6 +12,7 @@ def default_options(endpoint_path):
         'endpoint_path': endpoint_path,
 
         'api_key': None,
+        'skynet_api_key': None,
         'custom_user_agent': None,
         "timeout_seconds": None,
     }

--- a/tests/test_integration_upload.py
+++ b/tests/test_integration_upload.py
@@ -140,6 +140,33 @@ def test_upload_file_api_key():
 
 
 @responses.activate
+def test_upload_file_skynet_api_key():
+    """Test uploading a file with authorization."""
+
+    src_file = "./testdata/file1"
+
+    # Upload a file with an API password set.
+
+    responses.add_callback(
+        responses.POST,
+        "https://siasky.net/skynet/skyfile",
+        callback=response_callback
+    )
+
+    print("Uploading file "+src_file)
+    sialink2 = client.upload_file(src_file, {"skynet_api_key": "foobar"})
+    if SIALINK != sialink2:
+        sys.exit("ERROR: expected returned sialink "+SIALINK +
+                 ", received "+sialink2)
+    print("File upload successful, sialink: " + sialink2)
+
+    headers = responses.calls[0].request.headers
+    assert headers["Skynet-Api-Key"] == "foobar"
+
+    assert len(responses.calls) == 1
+
+
+@responses.activate
 def test_upload_file_custom_user_agent():
     """Test uploading a file with authorization."""
 


### PR DESCRIPTION
# PULL REQUEST

## Overview
Adds custom_opt for adding Skynet-Api-Key

Note: I tried modifying the tests, but something about my environment is causing various warnings and mocks to fail. Fileportal.org seemed to break tests as well without an API Key.

## Issues Closed
Closes #8 
